### PR TITLE
Fix inference form interactions and login redirect

### DIFF
--- a/LLM_review/templates/registration/login.html
+++ b/LLM_review/templates/registration/login.html
@@ -39,7 +39,7 @@
             </div>
         </div>
         
-        <input type="hidden" name="next" value="{{ next }}">
+        <input type="hidden" name="next" value="{{ next|default:'/' }}">
 
         <div>
             <button type="submit" class="w-full flex justify-center py-3 px-4 border border-transparent rounded-lg shadow-sm text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500">

--- a/LLM_review/templates/reviews/inference_page.html
+++ b/LLM_review/templates/reviews/inference_page.html
@@ -38,6 +38,15 @@
             {% endif %}
         </div>
     </header>
+    {% if messages %}
+    <div class="space-y-2 mb-6">
+        {% for message in messages %}
+        <div class="p-4 rounded-lg {% if message.tags == 'success' %}bg-green-100 text-green-700{% else %}bg-red-100 text-red-700{% endif %}">
+            {{ message }}
+        </div>
+        {% endfor %}
+    </div>
+    {% endif %}
 
     <!-- 관리자(is_staff)일 경우에만 추론 생성 폼을 보여줌 -->
     {% if user.is_staff %}
@@ -105,82 +114,89 @@
     // body 태그의 data-is-staff 속성에서 관리자 여부를 안전하게 읽어옵니다.
     const isStaff = document.body.dataset.isStaff === 'true';
 
-    // 관리자(is_staff)일 경우에만 동적 폼 스크립트를 실행
-    if (isStaff) {
-        let inputCounter = 0;
-        const container = document.getElementById('inputs-container');
+    let inputCounter = 0;
+    const container = document.getElementById('inputs-container');
 
-        function createInputBlock(type) {
-            const blockId = `input_block_${inputCounter}`;
-            const block = document.createElement('div');
-            block.id = blockId;
-            block.className = 'input-block bg-white p-4 rounded-lg shadow-sm relative';
+    function addTextBlock() {
+        if (!isStaff || !container) return;
+        createInputBlock('text');
+    }
 
-            const order = container.children.length;
+    function addImageBlock() {
+        if (!isStaff || !container) return;
+        createInputBlock('image');
+    }
 
-            let contentHtml = '';
-            if (type === 'text') {
-                contentHtml = `
-                    <label for="input_content_${inputCounter}" class="block text-sm font-semibold text-gray-600 mb-1">Text</label>
-                    <textarea name="input_content_${inputCounter}" class="w-full p-2 border border-gray-300 rounded-md" rows="3" placeholder="텍스트를 입력하세요."></textarea>
-                    <input type="hidden" name="input_type_${inputCounter}" value="text">
-                `;
-            } else if (type === 'image') {
-                contentHtml = `
-                    <label class="block text-sm font-semibold text-gray-600 mb-1">Image</label>
-                    <div class="flex items-center space-x-4">
-                        <img id="preview_${inputCounter}" src="https://placehold.co/100x100?text=Image" class="w-24 h-24 object-cover rounded-md bg-gray-100">
-                        <div class="flex-1">
-                            <input type="file" name="input_file_${inputCounter}" class="block w-full text-sm text-slate-500 file:mr-4 file:py-2 file:px-4 file:rounded-full file:border-0 file:text-sm file:font-semibold file:bg-blue-50 file:text-blue-700 hover:file:bg-blue-100" accept="image/*" onchange="previewImage(event, ${inputCounter})" required>
-                            <textarea name="input_content_${inputCounter}" class="w-full p-2 border border-gray-300 rounded-md mt-2" rows="2" placeholder="이미지에 대한 부연 설명을 입력하세요."></textarea>
-                        </div>
-                    </div>
-                     <input type="hidden" name="input_type_${inputCounter}" value="image">
-                `;
-            }
+    function createInputBlock(type) {
+        const blockId = `input_block_${inputCounter}`;
+        const block = document.createElement('div');
+        block.id = blockId;
+        block.className = 'input-block bg-white p-4 rounded-lg shadow-sm relative';
 
-            block.innerHTML = `
-                <input type="hidden" name="input_order_${inputCounter}" value="${order}">
-                ${contentHtml}
-                <button type="button" onclick="removeBlock('${blockId}')" class="absolute top-2 right-2 text-gray-400 hover:text-red-500">
-                    <i class="fas fa-times-circle"></i>
-                </button>
+        const order = container ? container.children.length : 0;
+
+        let contentHtml = '';
+        if (type === 'text') {
+            contentHtml = `
+                <label for="input_content_${inputCounter}" class="block text-sm font-semibold text-gray-600 mb-1">Text</label>
+                <textarea name="input_content_${inputCounter}" class="w-full p-2 border border-gray-300 rounded-md" rows="3" placeholder="텍스트를 입력하세요."></textarea>
+                <input type="hidden" name="input_type_${inputCounter}" value="text">
             `;
+        } else if (type === 'image') {
+            contentHtml = `
+                <label class="block text-sm font-semibold text-gray-600 mb-1">Image</label>
+                <div class="flex items-center space-x-4">
+                    <img id="preview_${inputCounter}" src="https://placehold.co/100x100?text=Image" class="w-24 h-24 object-cover rounded-md bg-gray-100">
+                    <div class="flex-1">
+                        <input type="file" name="input_file_${inputCounter}" class="block w-full text-sm text-slate-500 file:mr-4 file:py-2 file:px-4 file:rounded-full file:border-0 file:text-sm file:font-semibold file:bg-blue-50 file:text-blue-700 hover:file:bg-blue-100" accept="image/*" onchange="previewImage(event, ${inputCounter})" required>
+                        <textarea name="input_content_${inputCounter}" class="w-full p-2 border border-gray-300 rounded-md mt-2" rows="2" placeholder="이미지에 대한 부연 설명을 입력하세요."></textarea>
+                    </div>
+                </div>
+                <input type="hidden" name="input_type_${inputCounter}" value="image">
+            `;
+        }
 
-            container.appendChild(block);
-            inputCounter++;
+        block.innerHTML = `
+            <input type="hidden" name="input_order_${inputCounter}" value="${order}">
+            ${contentHtml}
+            <button type="button" onclick="removeBlock('${blockId}')" class="absolute top-2 right-2 text-gray-400 hover:text-red-500">
+                <i class="fas fa-times-circle"></i>
+            </button>
+        `;
+
+        container.appendChild(block);
+        inputCounter++;
+        updateOrders();
+    }
+
+    function removeBlock(blockId) {
+        const block = document.getElementById(blockId);
+        if (block && container) {
+            container.removeChild(block);
             updateOrders();
         }
-        
-        function removeBlock(blockId) {
-            const block = document.getElementById(blockId);
-            if (block) {
-                container.removeChild(block);
-                updateOrders();
-            }
-        }
-        
-        function updateOrders() {
-            Array.from(container.children).forEach((child, index) => {
-                const orderInput = child.querySelector('input[name^="input_order_"]');
-                if(orderInput) orderInput.value = index;
-            });
-        }
+    }
 
-        function previewImage(event, id) {
-            const reader = new FileReader();
-            reader.onload = function(){
-                const output = document.getElementById('preview_' + id);
-                output.src = reader.result;
-            };
-            reader.readAsDataURL(event.target.files[0]);
-        }
-        
-        // Add one text block by default
-        document.addEventListener('DOMContentLoaded', () => {
-            addTextBlock();
+    function updateOrders() {
+        if (!container) return;
+        Array.from(container.children).forEach((child, index) => {
+            const orderInput = child.querySelector('input[name^="input_order_"]');
+            if(orderInput) orderInput.value = index;
         });
-    } 
+    }
+
+    function previewImage(event, id) {
+        const reader = new FileReader();
+        reader.onload = function(){
+            const output = document.getElementById('preview_' + id);
+            output.src = reader.result;
+        };
+        reader.readAsDataURL(event.target.files[0]);
+    }
+
+    document.addEventListener('DOMContentLoaded', () => {
+        if (isStaff) addTextBlock();
+    });
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- ensure login redirects to home when no `next` parameter
- display Django messages on the inference page
- expose text/image add functions for admins
- parse dynamic input blocks when running inference

## Testing
- `python3 LLM_review/manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878908b13a083228cdc6bdb96864169