### PR TITLE
Fix missing namespace in reviews.urls

### DIFF
--- a/LLM_review/reviews/urls.py
+++ b/LLM_review/reviews/urls.py
@@ -1,6 +1,8 @@
 from django.urls import path
 from . import views
 
+app_name = "reviews"
+
 urlpatterns = [
     # 신규 추가: 로그인 후 첫 진입 페이지
     path('', views.root_view, name='root'),


### PR DESCRIPTION
## Summary
- register `reviews` app namespace to fix url reversing errors

## Testing
- `pip install django==5.2.4` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_687895b52ea083228824855e152a4594