### PR TITLE
Fix indentation error in inference redirect

### DIFF
--- a/LLM_review/reviews/views.py
+++ b/LLM_review/reviews/views.py
@@ -104,7 +104,7 @@ def run_inference(request):
             )
 
         messages.success(request, "추론이 완료되었습니다.")
-            return redirect("reviews:inference_list")
+        return redirect("reviews:inference_list")
 
     except genai.types.generation_types.StopCandidateException:
         inference.delete()


### PR DESCRIPTION
## Summary
- fix indentation in views.run_inference

## Testing
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68789802b67483229465ce0ffc5d19a9