### PR TITLE
Update inference layout and image drag

### DIFF
--- a/LLM_review/templates/reviews/inference_list.html
+++ b/LLM_review/templates/reviews/inference_list.html
@@ -35,15 +35,23 @@
     </header>
 
     <main class="grid grid-cols-1 md:grid-cols-3 gap-6">
-        <div class="md:col-span-2 space-y-6">
+        <!-- Left: Images, System Prompt, User Inputs -->
+        <div class="space-y-6">
+            <div id="detail-left" class="bg-white p-6 rounded-2xl shadow">
+                <p class="text-gray-500 text-center">항목을 선택하면 세부 정보가 표시됩니다.</p>
+            </div>
             <div id="eval-container" class="bg-white p-4 rounded-2xl shadow">
                 <p class="text-gray-500 text-center">우측 목록에서 항목을 선택하세요.</p>
             </div>
-            <div id="detail-container" class="grid grid-cols-1 md:grid-cols-2 gap-4 bg-white p-6 rounded-2xl shadow">
-                <p class="text-gray-500 text-center md:col-span-2">항목을 선택하면 세부 정보가 표시됩니다.</p>
-            </div>
         </div>
-        <div class="md:col-span-1">
+
+        <!-- Middle: Gemini Result -->
+        <div id="detail-result" class="bg-white p-6 rounded-2xl shadow">
+            <p class="text-gray-500 text-center">항목을 선택하면 결과가 표시됩니다.</p>
+        </div>
+
+        <!-- Right: Inference List -->
+        <div>
             <ul id="inference-list" class="space-y-2">
                 {% for inference in inferences %}
                 <li class="flex items-center space-x-2">
@@ -93,7 +101,8 @@ document.querySelectorAll('.inference-item').forEach(btn => {
 });
 
 function showDetail(data) {
-    const detail = document.getElementById('detail-container');
+    const detailLeft = document.getElementById('detail-left');
+    const detailResult = document.getElementById('detail-result');
     const evalBox = document.getElementById('eval-container');
     let imgs = '';
     let texts = '';
@@ -144,24 +153,23 @@ function showDetail(data) {
         </div>
     `;
 
-    detail.innerHTML = `
-        <div>
-            ${imgs ? `<div id="image-gallery" class="mb-4 flex flex-wrap">${imgs}</div>` : ''}
-            <div class="space-y-4">
-                <div>
-                    <h3 class="font-semibold mb-1">System Prompt</h3>
-                    <div class="prompt-box">${data.system_prompt || '(없음)'}</div>
-                </div>
-                <div>
-                    <h3 class="font-semibold mb-1">User Inputs</h3>
-                    ${texts || '<p class="text-sm text-gray-500">No inputs.</p>'}
-                </div>
+    detailLeft.innerHTML = `
+        ${imgs ? `<div id="image-gallery" class="mb-4 flex flex-wrap">${imgs}</div>` : ''}
+        <div class="space-y-4">
+            <div>
+                <h3 class="font-semibold mb-1">System Prompt</h3>
+                <div class="prompt-box">${data.system_prompt || '(없음)'}</div>
+            </div>
+            <div>
+                <h3 class="font-semibold mb-1">User Inputs</h3>
+                ${texts || '<p class="text-sm text-gray-500">No inputs.</p>'}
             </div>
         </div>
-        <div>
-            <h3 class="font-semibold mb-1">Gemini Result</h3>
-            <div class="prompt-box bg-blue-50 border-blue-200">${data.gemini_result}</div>
-        </div>
+    `;
+
+    detailResult.innerHTML = `
+        <h3 class="font-semibold mb-1">Gemini Result</h3>
+        <div class="prompt-box bg-blue-50 border-blue-200">${data.gemini_result}</div>
     `;
 
     document.querySelectorAll('#image-gallery img.thumbnail').forEach(img => {
@@ -237,6 +245,20 @@ imageModal.addEventListener('mousemove', e => {
 });
 
 window.addEventListener('mouseup', () => {
+    if (dragging) {
+        dragging = false;
+        modalImg.style.cursor = 'grab';
+    }
+});
+
+imageModal.addEventListener('mouseup', () => {
+    if (dragging) {
+        dragging = false;
+        modalImg.style.cursor = 'grab';
+    }
+});
+
+modalImg.addEventListener('mouseleave', () => {
     if (dragging) {
         dragging = false;
         modalImg.style.cursor = 'grab';


### PR DESCRIPTION
## Summary
- reorganize `inference_list.html` into a three-column layout
- split details into left and center panels
- ensure image drag stops on mouse release

## Testing
- `python LLM_review/manage.py test` *(fails: Django not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6878a19049a0832292018f013a26f63a