### PR TITLE
Fix input ordering and parameter controls

### DIFF
--- a/LLM_review/reviews/views.py
+++ b/LLM_review/reviews/views.py
@@ -73,12 +73,17 @@ def run_inference(request):
     )
 
     prompt_parts = []
+    text_added = False
     for item in input_items:
         if item["type"] == "text":
             prompt_parts.append(item["content"])
+            if item["content"].strip():
+                text_added = True
         elif item["type"] == "image" and item["file"]:
             try:
                 img = Image.open(item["file"])
+                if not text_added and not prompt_parts:
+                    prompt_parts.append("")
                 prompt_parts.append(img)
             except Exception as e:
                 logger.error(f"Error processing image file {item['file'].name}: {e}")

--- a/LLM_review/templates/reviews/inference_page.html
+++ b/LLM_review/templates/reviews/inference_page.html
@@ -79,12 +79,18 @@
             <div class="md:col-span-1 bg-white p-6 rounded-2xl shadow-lg space-y-6">
                 <h2 class="text-xl font-semibold mb-2">Parameters</h2>
                 <div>
-                    <label for="temperature" class="block text-sm font-medium text-slate-600">Temperature: <span id="temp_val">0.7</span></label>
-                    <input type="range" id="temperature" name="temperature" min="0" max="1" step="0.1" value="0.7" class="w-full h-2 bg-slate-200 rounded-lg appearance-none cursor-pointer" oninput="document.getElementById('temp_val').textContent = this.value">
+                    <label class="block text-sm font-medium text-slate-600" for="temperature">Temperature</label>
+                    <div class="flex items-center space-x-2">
+                        <input type="range" id="temperature_range" min="0" max="2" step="0.5" value="1" class="flex-1 h-2 bg-slate-200 rounded-lg appearance-none cursor-pointer" oninput="document.getElementById('temperature').value=this.value">
+                        <input type="number" id="temperature" name="temperature" min="0" max="2" step="0.5" value="1" class="w-16 p-1 border rounded text-sm" oninput="document.getElementById('temperature_range').value=this.value">
+                    </div>
                 </div>
                 <div>
-                    <label for="top_p" class="block text-sm font-medium text-slate-600">Top P: <span id="topp_val">1.0</span></label>
-                    <input type="range" id="top_p" name="top_p" min="0" max="1" step="0.1" value="1.0" class="w-full h-2 bg-slate-200 rounded-lg appearance-none cursor-pointer" oninput="document.getElementById('topp_val').textContent = this.value">
+                    <label class="block text-sm font-medium text-slate-600" for="top_p">Top P</label>
+                    <div class="flex items-center space-x-2">
+                        <input type="range" id="top_p_range" min="0" max="1" step="0.5" value="1" class="flex-1 h-2 bg-slate-200 rounded-lg appearance-none cursor-pointer" oninput="document.getElementById('top_p').value=this.value">
+                        <input type="number" id="top_p" name="top_p" min="0" max="1" step="0.5" value="1" class="w-16 p-1 border rounded text-sm" oninput="document.getElementById('top_p_range').value=this.value">
+                    </div>
                 </div>
                 <div>
                     <label for="max_output_tokens" class="block text-sm font-medium text-slate-600">Max Output Tokens</label>


### PR DESCRIPTION
## Summary
- allow image as first prompt by inserting blank text
- add linked number/range inputs for temperature and top_p

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6878af123290832287b87cca5da74890