### PR TITLE
Implement bootstrap evaluation interface

### DIFF
--- a/LLM_review/reviews/views.py
+++ b/LLM_review/reviews/views.py
@@ -206,6 +206,9 @@ def evaluation_page(request, inference_id):
     )
     user_has_evaluated = evaluations.filter(evaluator=request.user).exists()
 
+    # 평가 페이지 우측 목록 표시를 위한 전체 추론 목록
+    inferences = Inference.objects.all().order_by('-created_at')
+
     context = {
         "inference": inference,
         "inference_id": inference.id,
@@ -213,6 +216,7 @@ def evaluation_page(request, inference_id):
         "agreement_rate": agreement_rate,
         "avg_quality": avg_quality,
         "user_has_evaluated": user_has_evaluated,
+        "inferences": inferences,
     }
 
     return render(request, "reviews/evaluation_page.html", context)

--- a/LLM_review/templates/reviews/evaluation_page.html
+++ b/LLM_review/templates/reviews/evaluation_page.html
@@ -3,149 +3,135 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>상세 평가 페이지</title>
-    <script src="https://cdn.tailwindcss.com"></script>
-    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
-    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;500;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/github-markdown-css/5.1.0/github-markdown.min.css">
+    <title>LLM 평가 페이지</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css">
     <style>
-        body { font-family: 'Noto Sans KR', sans-serif; }
-        .prompt-box { background-color: #f8fafc; border: 1px solid #e2e8f0; padding: 1rem; border-radius: 0.5rem; white-space: pre-wrap; font-family: monospace; }
-        .star-rating input[type="radio"] { display: none; }
-        .star-rating label { font-size: 2rem; color: #d1d5db; cursor: pointer; transition: color 0.2s; }
-        .star-rating input[type="radio"]:checked ~ label, .star-rating label:hover, .star-rating label:hover ~ label { color: #f59e0b; }
+        body { background-color: #f0f2f5; }
+        .card { border: none; box-shadow: 0 1px 3px rgba(0,0,0,0.12), 0 1px 2px rgba(0,0,0,0.24); }
+        .accordion-button:not(.collapsed) { background-color: #e7f1ff; color: #0c63e4; }
+
+        /* LLM 결과 JSON을 테이블로 표시 */
+        .json-key {
+            font-weight: bold;
+            color: #555;
+            width: 25%; /* 키(key) 영역 너비 */
+        }
+
+        /* 오른쪽 추론 목록 활성 아이템 스타일 */
+        .list-group-item.active {
+            background-color: #0d6efd;
+            border-color: #0d6efd;
+        }
+
+        /* 평가 영역 스타일 */
+        .evaluation-box {
+            display: flex;
+            align-items: center;
+            gap: 1.5rem; /* 각 평가 요소 사이의 간격 */
+            background-color: #fff;
+            padding: 1rem;
+            border-radius: 0.5rem;
+            box-shadow: 0 1px 3px rgba(0,0,0,0.12), 0 1px 2px rgba(0,0,0,0.24);
+        }
+        .evaluation-box .form-label { margin-bottom: 0.25rem; font-weight: bold; font-size: 0.9rem; }
+        .rating-stars { cursor: pointer; color: #ccc; }
+        .rating-stars .fa-star:hover, .rating-stars .fa-star.selected { color: #ffc107; }
     </style>
 </head>
-<body class="bg-slate-100">
-<div class="w-full px-4 sm:px-6 lg:px-8 grid grid-cols-1 lg:grid-cols-3 gap-8">
-    <!-- Left: Inference Details -->
-    <div class="lg:col-span-2 bg-white p-6 rounded-2xl shadow-lg space-y-6">
-        <div class="border-b pb-4">
-            <a href="{% url 'reviews:inference_list' %}" class="text-blue-600 hover:underline mb-4 inline-block"><i class="fas fa-arrow-left mr-2"></i>목록으로 돌아가기</a>
-            <h1 class="text-3xl font-bold text-slate-800">추론 결과 상세</h1>
-            <p class="text-sm text-slate-500 mt-1">ID: {{ inference_id }}</p>
-        </div>
-
-        <div>
-            <h2 class="text-xl font-semibold text-slate-700 mb-2">System Prompt</h2>
-            <div class="prompt-box">{{ inference.systemPrompt|default:"(없음)" }}</div>
-        </div>
-
-        <div>
-            <h2 class="text-xl font-semibold text-slate-700 mb-2">User Inputs</h2>
-            <div class="space-y-2">
-            <!-- 모델 관계를 통해 inputs를 가져오도록 수정: inference.inputs.all -->
-            {% for input in inference.inputs.all %}
-                <div class="prompt-box">
-                    <span class="font-bold text-sm text-slate-500">[{{ input.order }}] {{ input.input_type }}:</span>
-                    
-                    {# 이미지 타입이고 이미지 파일이 존재할 경우, URL을 통해 화면에 표시 #}
-                    {% if input.input_type == 'image' and input.image %}
-                        <img src="{{ input.image.url }}" alt="User uploaded image {{ input.order }}" class="my-2 max-w-sm rounded-md shadow-md">
-                    {% endif %}
-
-                    {# 텍스트 내용 또는 이미지의 부연 설명 표시 #}
-                    {{ input.content }}
-                </div>
-            {% endfor %}
-            </div>
-        </div>
-        
-        <div>
-            <h2 class="text-xl font-semibold text-slate-700 mb-2">Gemini Result</h2>
-            <div class="prompt-box bg-blue-50 border-blue-200">
-                <div id="gemini-result" class="markdown-body max-h-64 overflow-hidden">
-                    {{ inference.gemini_result|linebreaksbr }}
-                </div>
-                <button id="toggle-result" class="mt-2 text-blue-600 text-sm">펼치기</button>
-            </div>
-        </div>
-    </div>
-
-    <!-- Right: Evaluation Section -->
-    <div class="lg:col-span-1 space-y-6">
-        <div class="bg-white p-6 rounded-2xl shadow-lg">
-            <h2 class="text-xl font-semibold mb-4 border-b pb-3">평가 현황</h2>
-            <div class="space-y-3 text-sm">
-                <div class="flex justify-between"><span>총 평가자 수:</span> <span class="font-bold">{{ eval_count }} 명</span></div>
-                <div class="flex justify-between"><span>Agreement 비율:</span> <span class="font-bold">{{ agreement_rate }} %</span></div>
-                <div class="flex justify-between"><span>평균 Quality:</span> <span class="font-bold">{{ avg_quality }} / 5.0</span></div>
-            </div>
-        </div>
-        
-        <div class="bg-white p-6 rounded-2xl shadow-lg">
-            <h2 class="text-xl font-semibold mb-4 border-b pb-3">나의 평가</h2>
-            {% if user.is_staff %}
-                <div class="text-center p-4 bg-yellow-50 border border-yellow-200 rounded-lg">
-                    <p class="text-sm text-yellow-800">관리자는 평가할 수 없습니다.</p>
-                </div>
-            {% elif user_has_evaluated %}
-                <div class="text-center p-4 bg-green-50 border border-green-200 rounded-lg">
-                    <p class="text-sm text-green-800">이미 이 항목을 평가했습니다.</p>
-                </div>
-            {% else %}
-            <form action="{% url 'reviews:submit_evaluation' inference_id=inference_id %}" method="POST">
-                {% csrf_token %}
-                <div class="space-y-6">
-                    <div>
-                        <label class="block text-sm font-medium text-slate-600 mb-2">Agreement (결과가 지시를 잘 따랐나요?)</label>
-                        <div class="flex space-x-2">
-                            <button type="button" data-value="true" class="eval-btn agreement-btn flex-1 p-3 border rounded-lg">O</button>
-                            <button type="button" data-value="false" class="eval-btn agreement-btn flex-1 p-3 border rounded-lg">X</button>
-                        </div>
-                        <input type="hidden" name="agreement" id="agreement-input" required>
-                    </div>
-                    <div>
-                        <label class="block text-sm font-medium text-slate-600 mb-2">Quality (결과의 전반적인 품질)</label>
-                        <div class="star-rating flex flex-row-reverse justify-center items-center">
-                            <input type="radio" id="star5" name="quality" value="5" required><label for="star5" title="5점"><i class="fas fa-star"></i></label>
-                            <input type="radio" id="star4" name="quality" value="4"><label for="star4" title="4점"><i class="fas fa-star"></i></label>
-                            <input type="radio" id="star3" name="quality" value="3"><label for="star3" title="3점"><i class="fas fa-star"></i></label>
-                            <input type="radio" id="star2" name="quality" value="2"><label for="star2" title="2점"><i class="fas fa-star"></i></label>
-                            <input type="radio" id="star1" name="quality" value="1"><label for="star1" title="1점"><i class="fas fa-star"></i></label>
+<body>
+<div class="container-fluid p-3 p-md-4">
+    <div class="row">
+        <main class="col-md-9">
+            <div class="accordion mb-3" id="promptAccordion">
+                <div class="accordion-item">
+                    <h2 class="accordion-header">
+                        <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#collapseSystem">
+                            System Prompt
+                        </button>
+                    </h2>
+                    <div id="collapseSystem" class="accordion-collapse collapse show" data-bs-parent="#promptAccordion">
+                        <div class="accordion-body">
+                            {{ inference.system_prompt|default:"(없음)" }}
                         </div>
                     </div>
-                    <div>
-                        <label for="comment" class="block text-sm font-medium text-slate-600 mb-1">코멘트 (선택)</label>
-                        <textarea name="comment" id="comment" rows="3" class="w-full p-2 border border-slate-300 rounded-lg"></textarea>
-                    </div>
-                    <button type="submit" class="w-full bg-blue-600 text-white font-bold py-3 rounded-lg hover:bg-blue-700">평가 제출</button>
                 </div>
-            </form>
-            <script>
-                const agreementBtns = document.querySelectorAll('.agreement-btn');
-                const agreementInput = document.getElementById('agreement-input');
-                agreementBtns.forEach(btn => {
-                    btn.addEventListener('click', () => {
-                        agreementBtns.forEach(b => b.classList.remove('bg-blue-500', 'text-white'));
-                        btn.classList.add('bg-blue-500', 'text-white');
-                        agreementInput.value = btn.dataset.value;
-                    });
-                });
-            </script>
-            {% endif %}
-        </div>
+                <div class="accordion-item">
+                    <h2 class="accordion-header">
+                        <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseInputs">
+                            User Inputs
+                        </button>
+                    </h2>
+                    <div id="collapseInputs" class="accordion-collapse collapse" data-bs-parent="#promptAccordion">
+                        <div class="accordion-body">
+                            {% for input in inference.inputs.all %}
+                                <div class="mb-2">
+                                    <span class="fw-bold small text-muted">[{{ input.order }}] {{ input.input_type }}:</span>
+                                    {% if input.input_type == 'image' and input.image %}
+                                        <img src="{{ input.image.url }}" alt="User uploaded image {{ input.order }}" class="img-fluid rounded my-2" style="max-width:200px;">
+                                    {% endif %}
+                                    {{ input.content }}
+                                </div>
+                            {% endfor %}
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="card mb-3">
+                <div class="card-header fw-bold">LLM Result</div>
+                <div class="card-body">
+                    <pre class="mb-0">{{ inference.gemini_result }}</pre>
+                </div>
+            </div>
+
+            <div class="evaluation-box">
+                <div>
+                    <label class="form-label">Agreement</label>
+                    <div class="btn-group" role="group">
+                        <input type="radio" class="btn-check" name="agreement" id="agreement-o" autocomplete="off">
+                        <label class="btn btn-outline-success" for="agreement-o">O</label>
+
+                        <input type="radio" class="btn-check" name="agreement" id="agreement-x" autocomplete="off">
+                        <label class="btn btn-outline-danger" for="agreement-x">X</label>
+                    </div>
+                </div>
+                <div>
+                    <label class="form-label">Quality</label>
+                    <div class="rating-stars h4 m-0">
+                        <i class="fa-solid fa-star"></i><i class="fa-solid fa-star"></i><i class="fa-solid fa-star"></i><i class="fa-solid fa-star"></i><i class="fa-solid fa-star"></i>
+                    </div>
+                </div>
+                <div class="flex-grow-1">
+                    <label class="form-label">Comment</label>
+                    <input type="text" class="form-control" placeholder="Comment">
+                </div>
+                <div>
+                    <label class="form-label d-block" style="opacity: 0;">.</label> <button type="submit" class="btn btn-primary">Submit</button>
+                </div>
+            </div>
+        </main>
+        <aside class="col-md-3">
+            <div class="card">
+                <div class="card-header fw-bold">LLM Inference list</div>
+                <ul class="list-group list-group-flush">
+                    {% for item in inferences %}
+                        <a href="{% url 'reviews:evaluation_page' item.id %}" class="list-group-item list-group-item-action {% if item.id == inference_id %}active{% endif %}">
+                            {{ item.id }}. {{ item.requester.username }}
+                        </a>
+                    {% endfor %}
+                </ul>
+            </div>
+        </aside>
     </div>
 </div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 <script>
-    document.addEventListener('DOMContentLoaded', () => {
-        const resultDiv = document.getElementById('gemini-result');
-        if (resultDiv) {
-            resultDiv.innerHTML = marked.parse(resultDiv.textContent);
-            const toggleBtn = document.getElementById('toggle-result');
-            let collapsed = true;
-            toggleBtn.addEventListener('click', () => {
-                collapsed = !collapsed;
-                if (collapsed) {
-                    resultDiv.classList.add('max-h-64', 'overflow-hidden');
-                    toggleBtn.textContent = '펼치기';
-                } else {
-                    resultDiv.classList.remove('max-h-64', 'overflow-hidden');
-                    toggleBtn.textContent = '접기';
-                }
-            });
-        }
+    document.querySelectorAll('.rating-stars .fa-star').forEach(star => {
+        star.addEventListener('click', function() {
+            let parent = this.parentElement;
+            parent.querySelectorAll('.fa-star').forEach(s => s.classList.remove('selected'));
+            this.classList.add('selected');
+        });
     });
 </script>
 </body>


### PR DESCRIPTION
## Summary
- redesign evaluation_page.html with Bootstrap and Font Awesome
- show inference list sidebar and apply new rating logic
- supply inference list from `evaluation_page` view
- simplify the evaluation layout by removing evaluation stats

## Testing
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*


------
https://chatgpt.com/codex/tasks/task_e_6879ead26f548322a6cb54b79015eadb